### PR TITLE
Handle forward slashes in commit messages

### DIFF
--- a/generate-index.ts
+++ b/generate-index.ts
@@ -83,6 +83,7 @@ function getCommitsForFile(filename: string, callback: (result: Commit[]) => voi
     proc.exec('git ' + args.join(' '), { cwd: dtRoot }, (err, stdout) => {
         if (err) throw err;
         var x = stdout.toString('UTF-8');
+        x = x.replace(/\\/g, '/');
         x = x.replace(/\"/g, '\\\"');
         x = x.replace(new RegExp(fakeQuote, 'g'), '"');
         x = x.replace(new RegExp(eol, 'g'), ',');


### PR DESCRIPTION
Seems like there weren't any forward slashes in the commit message history when this was first written.